### PR TITLE
Enable capability TRANSACTIONINFO

### DIFF
--- a/src/socket/socketWrapper.ts
+++ b/src/socket/socketWrapper.ts
@@ -14,7 +14,7 @@ import {
 import Session from "../session";
 
 class SocketWrapper {
-  private capabilityClient: string = 'CLEAR HEARTBEAT PRICES PUMPS PUMPSTATUS QUIT TRANSACTIONS SESSIONMODE LOCKPUMP UNLOCKPUMP';
+  private capabilityClient: string = 'CLEAR HEARTBEAT PRICES PUMPS PUMPSTATUS QUIT TRANSACTIONS SESSIONMODE LOCKPUMP UNLOCKPUMP TRANSACTIONINFO';
   private capabilityServerRequestID: string = 'CSR';
   private counter: number = 0;
   private isMultiplexing: boolean = false;


### PR DESCRIPTION
Only will have effect when the station is configured appropriately and the fuel card provider allows passing card details.